### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      javascript:
+        patterns: ["*"]
+    labels: ["dependencies", "javascript"]
+    commit-message:
+      prefix: "build"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
     groups:
       javascript:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "hardhat"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "chalk"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies", "javascript"]
     commit-message:
       prefix: "build"


### PR DESCRIPTION
Adds `.github/dependabot.yml` mirroring the config used in `core`: weekly schedule, 7-day cooldown, grouped updates per ecosystem, conventional commit prefixes.

### Ignore rules
- **hardhat** majors: v3 is a breaking rewrite; `hardhat-deploy`/`hardhat-tracer`/`hardhat-watcher` here are built against the v2 API
- **chalk** majors: v5+ is ESM-only, the CLI is CommonJS