### PR TITLE
docs: add archive notice for Chainlink CCIP migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Multichain Automaton ⚙️
 
+> [!WARNING]
+> **Outdated due to the Chainlink partnership**
+>
+> Per the [Lido DAO mandate](https://snapshot.box/#/s:lido-snapshot.eth/proposal/0xf842517c2ffba082efac87ec43365e86548adb38e24d1446d850c7d7b979c423), the Lido Ecosystem is working to establish [Chainlink CCIP as the official default cross-chain infrastructure for wstETH](https://research.lido.fi/t/announcing-strategic-partnership-with-chainlink-on-adopting-ccip-as-the-official-default-cross-chain-infrastructure-for-wsteth/10871). The bridging architecture and recommendations here reflect the pre-CCIP setup. This repository is archived and no longer maintained.
+
 ![](/assets/logo.jpg)
 
 ## Overview


### PR DESCRIPTION
This pull request updates the `README.md` to clarify the project's status. A warning notice has been added to indicate that the repository is now archived and outdated due to the Chainlink partnership, and that it is no longer maintained.

Repository status update:

* Added a prominent warning at the top of `README.md` stating the repository is archived and outdated, with references to the Lido DAO mandate and the adoption of Chainlink CCIP as the official cross-chain infrastructure for wstETH.